### PR TITLE
Feature/163153545/hash store password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 PORT=<port number>
 DEV_DATABASE_URL=postgres://127.0.0.1:5432/<DB_NAME>
+NODE_ENV=test

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 PORT=<port number>
 DEV_DATABASE_URL=postgres://127.0.0.1:5432/<DB_NAME>
-NODE_ENV=test
+NODE_ENV=development

--- a/models/user.js
+++ b/models/user.js
@@ -41,6 +41,9 @@ module.exports = (sequelize, DataTypes) => {
     this.password = await bcrypt.hash(this.password, saltRounds);
   };
 
+  User.prototype.validPassword = function validPassword(password) {
+    return bcrypt.compare(password, this.password);
+  };
 
   return User;
 };

--- a/models/user.js
+++ b/models/user.js
@@ -24,16 +24,23 @@ module.exports = (sequelize, DataTypes) => {
     },
   }, {
     hooks: {
-      beforeCreate: (user) => {
-        const salt = bcrypt.genSaltSync(10);
-        user.password = bcrypt.hashSync(user.password, salt);
+      beforeCreate: async (user) => {
+        await user.hashPassword();
       }
     }
   }
   );
+
   User.associate = models => User.hasOne(models.Profile, {
     foreignKey: 'userId',
     onDelete: 'CASCADE'
   });
+
+  User.prototype.hashPassword = async function hashPassword() {
+    const saltRounds = 10;
+    this.password = await bcrypt.hash(this.password, saltRounds);
+  };
+
+
   return User;
 };

--- a/models/user.js
+++ b/models/user.js
@@ -1,3 +1,5 @@
+import bcrypt from 'bcrypt';
+
 module.exports = (sequelize, DataTypes) => {
   const User = sequelize.define('User', {
     username: {
@@ -20,7 +22,15 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: false
     },
-  });
+  }, {
+    hooks: {
+      beforeCreate: (user) => {
+        const salt = bcrypt.genSaltSync(10);
+        user.password = bcrypt.hashSync(user.password, salt);
+      }
+    }
+  }
+  );
   User.associate = models => User.hasOne(models.Profile, {
     foreignKey: 'userId',
     onDelete: 'CASCADE'

--- a/models/user.js
+++ b/models/user.js
@@ -39,6 +39,7 @@ module.exports = (sequelize, DataTypes) => {
   User.prototype.hashPassword = async function hashPassword() {
     const saltRounds = 10;
     this.password = await bcrypt.hash(this.password, saltRounds);
+    return this.password;
   };
 
   User.prototype.validPassword = function validPassword(password) {


### PR DESCRIPTION
#### What does this PR do?
- It encrypts passwords before storing in User model
#### Description of Task to be completed?
- [x] add a <code>beforeCreate</code> hook to User model to hash password before storage
#### How should this be manually tested?
- send a valid post request to <code>/users</code> and check the password column of the User table in the database for the newly added user
- alternatively you can run <code>npm test</code> and check the test database
- you should see an hash in place of a plain string
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#163153545](https://www.pivotaltracker.com/n/projects/2229853/stories/163153545)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12197866/51055167-589bb300-15df-11e9-95d0-d35eada836d9.png)
