### PR TITLE
[#163357750] make table names in migration files plural

### DIFF
--- a/migrations/005-create-follow-table.js
+++ b/migrations/005-create-follow-table.js
@@ -1,5 +1,5 @@
 module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable('Follow', {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Follows', {
     id: {
       allowNull: false,
       primaryKey: true,
@@ -31,5 +31,5 @@ module.exports = {
       type: Sequelize.DATE
     }
   }),
-  down: queryInterface => queryInterface.dropTable('Follow')
+  down: queryInterface => queryInterface.dropTable('Follows')
 };

--- a/migrations/007-create-reaction-table.js
+++ b/migrations/007-create-reaction-table.js
@@ -1,5 +1,5 @@
 module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable('Reaction', {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Reactions', {
     id: {
       allowNull: false,
       primaryKey: true,
@@ -39,5 +39,5 @@ module.exports = {
       type: Sequelize.DATE
     }
   }),
-  down: queryInterface => queryInterface.dropTable('Reaction')
+  down: queryInterface => queryInterface.dropTable('Reactions')
 };

--- a/migrations/008-create-bookmark-table.js
+++ b/migrations/008-create-bookmark-table.js
@@ -1,5 +1,5 @@
 module.exports = {
-  up: (queryInterface, Sequelize) => queryInterface.createTable('Bookmark', {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Bookmarks', {
     id: {
       allowNull: false,
       primaryKey: true,
@@ -35,5 +35,5 @@ module.exports = {
       type: Sequelize.DATE
     }
   }),
-  down: queryInterface => queryInterface.dropTable('Bookmark')
+  down: queryInterface => queryInterface.dropTable('Bookmarks')
 };


### PR DESCRIPTION
#### What does this PR do?
This PR makes the table names in the migration files plural 

#### Any background context you want to provide?
The conflicting names caused the `follow` and `reactions` table to be created twice
#### Screenshots
Before:
<img width="908" alt="screen shot 2019-01-21 at 3 52 49 pm" src="https://user-images.githubusercontent.com/43746609/51482085-c8572e00-1d95-11e9-9ee7-2f9972209b3b.png">

After:
<img width="1271" alt="screen shot 2019-01-21 at 3 57 52 pm" src="https://user-images.githubusercontent.com/43746609/51482115-d73de080-1d95-11e9-80eb-bb298f51d67d.png">
