### PR TITLE
[Bug: #163397301] Fix invalid category error

### DIFF
--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -30,7 +30,9 @@ class Profiles {
 
     let normalizedInterests;
 
-    normalizedInterests = interests;
+    if (!profile.interests) {
+      normalizedInterests = interests;
+    }
     if (profile.interests) {
       normalizedInterests = [
         ...new Set(profile.interests.concat(interests))
@@ -42,7 +44,7 @@ class Profiles {
         firstName: firstName || profile.firstName,
         lastName: lastName || profile.lastName,
         bio: bio || profile.bio,
-        interests: normalizedInterests || profile.interests,
+        interests: normalizedInterests,
         imageUrl: imageUrl || profile.imageUrl
       });
     return res.json({

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -20,21 +20,32 @@ class Profiles {
     const profile = await Profile.findOne({
       where: { userId: req.decoded.id }
     });
-    const userProfile = await profile
+
+    const {
+      firstName,
+      lastName,
+      bio,
+      imageUrl,
+      interests = []
+    } = req.body;
+
+    const normalizedInterests = [...new Set(profile.interests.concat(interests))];
+
+    const responseData = await profile
       .update({
-        firstName: req.body.firstName || profile.firstName,
-        lastName: req.body.lastName || profile.lastName,
-        bio: req.body.bio || profile.bio,
-        interests: req.body.interests || profile.interests,
-        imageUrl: req.body.imageUrl || profile.imageUrl
+        firstName: firstName || profile.firstName,
+        lastName: lastName || profile.lastName,
+        bio: bio || profile.bio,
+        interests: normalizedInterests || profile.interests,
+        imageUrl: imageUrl || profile.imageUrl
       });
     return res.json({
       message: 'Profile updated successfully',
-      firstName: userProfile.firstName,
-      lastName: userProfile.lastName,
-      bio: userProfile.bio,
-      interests: userProfile.interests,
-      imageURL: userProfile.imageURL
+      firstName: responseData.firstName,
+      lastName: responseData.lastName,
+      bio: responseData.bio,
+      interests: responseData.interests,
+      imageURL: responseData.imageURL
     });
   }
 }

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -29,7 +29,14 @@ class Profiles {
       interests = []
     } = req.body;
 
-    const normalizedInterests = [...new Set(profile.interests.concat(interests))];
+    let normalizedInterests;
+
+    normalizedInterests = interests;
+    if (profile.interests) {
+      normalizedInterests = [
+        ...new Set(profile.interests.concat(interests))
+      ];
+    }
 
     const responseData = await profile
       .update({

--- a/helpers/convertToArray.js
+++ b/helpers/convertToArray.js
@@ -1,0 +1,4 @@
+export default (value = '') => {
+  if (!Array.isArray(value)) return [value.toString()];
+  return value;
+};

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,2 +1,3 @@
 export { default as generateSlug } from './generateSlug';
 export { default as categories } from './categories';
+export { default as convertToArray } from './convertToArray';

--- a/middlewares/articleValidation.js
+++ b/middlewares/articleValidation.js
@@ -1,11 +1,39 @@
 import Sequelize from 'sequelize';
 import models from '../models';
+import { categories as categoryEnum } from '../helpers';
 
 const { Article } = models;
 const requiredParams = ['title', 'body', 'description', 'category'];
 const { iLike } = Sequelize.Op;
 
 export default {
+  categoryValidator(req, res, next) {
+    let { category } = req.body;
+
+    if (!Array.isArray(category)) {
+      category = [category.toString()];
+    }
+
+    const errorArray = [];
+
+    (category).forEach((item) => {
+      if (!categoryEnum.includes(item)) {
+        errorArray.push(item);
+      }
+    });
+
+    if (!errorArray.length) return next();
+
+    const pluralize = errorArray.length === 1 ? 'category' : 'categories';
+    const stringifiedErrorArray = JSON.stringify(errorArray);
+    const stringifiedAllowedCategories = JSON.stringify(categoryEnum);
+    // eslint-disable-next-line
+      const errorMessage = `Invalid ${pluralize} ${stringifiedErrorArray}. Allowed categories are ${stringifiedAllowedCategories}`;
+    const error = new Error(errorMessage);
+    error.status = 400;
+    return next(error);
+  },
+
   expectedParamsValidator(req, res, next) {
     const errorArray = [];
 

--- a/middlewares/articleValidation.js
+++ b/middlewares/articleValidation.js
@@ -8,30 +8,18 @@ const { iLike } = Sequelize.Op;
 
 export default {
   categoryValidator(req, res, next) {
-    let { category } = req.body;
+    const { category } = req.body;
 
-    if (!Array.isArray(category)) {
-      category = [category.toString()];
+    if (!categoryEnum.includes(category)) {
+      const stringifiedAllowedCategories = JSON.stringify(categoryEnum);
+      // eslint-disable-next-line
+      const errorMessage = `Invalid category [${category}]. Allowed categories are ${stringifiedAllowedCategories}`;
+      const error = new Error(errorMessage);
+      error.status = 400;
+      return next(error);
     }
 
-    const errorArray = [];
-
-    (category).forEach((item) => {
-      if (!categoryEnum.includes(item)) {
-        errorArray.push(item);
-      }
-    });
-
-    if (!errorArray.length) return next();
-
-    const pluralize = errorArray.length === 1 ? 'category' : 'categories';
-    const stringifiedErrorArray = JSON.stringify(errorArray);
-    const stringifiedAllowedCategories = JSON.stringify(categoryEnum);
-    // eslint-disable-next-line
-      const errorMessage = `Invalid ${pluralize} ${stringifiedErrorArray}. Allowed categories are ${stringifiedAllowedCategories}`;
-    const error = new Error(errorMessage);
-    error.status = 400;
-    return next(error);
+    return next();
   },
 
   expectedParamsValidator(req, res, next) {

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 export default (err, req, res, next) => {
-  res.status(err.status).send({
+  console.log('==twitter error====', err);
+  res.status(err.status || 500).send({
     error: err.message
   });
 };

--- a/middlewares/errorHandler.js
+++ b/middlewares/errorHandler.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 export default (err, req, res, next) => {
-  console.log('==twitter error====', err);
-  res.status(err.status || 500).send({
+  res.status(err.status).send({
     error: err.message
   });
 };

--- a/middlewares/profileValidations.js
+++ b/middlewares/profileValidations.js
@@ -1,19 +1,18 @@
 import validation from 'validator';
-import { categories as interestsEnum } from '../helpers';
+import { categories as interestsEnum, convertToArray } from '../helpers';
 
 export default {
   interestsValidator(req, res, next) {
     if (req.body.interests) {
-      let { interests } = req.body;
-      if (!Array.isArray(interests)) {
-        interests = [interests.toString()];
-      }
+      const interests = convertToArray(req.body.interests);
       const errorArray = [];
+
       (interests).forEach((item) => {
         if (!interestsEnum.includes(item)) {
           errorArray.push(item);
         }
       });
+
       if (!errorArray.length) return next();
       const pluralize = errorArray.length === 1 ? 'category' : 'categories';
       const stringifiedErrorArray = JSON.stringify(errorArray);

--- a/middlewares/profileValidations.js
+++ b/middlewares/profileValidations.js
@@ -3,23 +3,18 @@ import { categories as interestsEnum } from '../helpers';
 
 export default {
   interestsValidator(req, res, next) {
-    let { interests } = req.body;
-
-    if (!Array.isArray(interests)) {
-      interests = [interests.toString()];
-    }
-
-    if (Object.keys(req.body).includes('interests')) {
+    if (req.body.interests) {
+      let { interests } = req.body;
+      if (!Array.isArray(interests)) {
+        interests = [interests.toString()];
+      }
       const errorArray = [];
-
       (interests).forEach((item) => {
         if (!interestsEnum.includes(item)) {
           errorArray.push(item);
         }
       });
-
       if (!errorArray.length) return next();
-
       const pluralize = errorArray.length === 1 ? 'category' : 'categories';
       const stringifiedErrorArray = JSON.stringify(errorArray);
       const stringifiedAllowedCategories = JSON.stringify(interestsEnum);

--- a/middlewares/profileValidations.js
+++ b/middlewares/profileValidations.js
@@ -3,10 +3,16 @@ import { categories as interestsEnum } from '../helpers';
 
 export default {
   interestsValidator(req, res, next) {
+    let { interests } = req.body;
+
+    if (!Array.isArray(interests)) {
+      interests = [interests.toString()];
+    }
+
     if (Object.keys(req.body).includes('interests')) {
       const errorArray = [];
 
-      (req.body.interests).forEach((item) => {
+      (interests).forEach((item) => {
         if (!interestsEnum.includes(item)) {
           errorArray.push(item);
         }

--- a/routes/articleRoutes.js
+++ b/routes/articleRoutes.js
@@ -2,18 +2,17 @@ import express from 'express';
 import { Article } from '../controllers';
 import {
   verifyToken,
-  articleValidation,
-  profileValidations
+  articleValidation
 } from '../middlewares';
 
 const router = express.Router();
 
 const { createArticle } = Article;
-const { interestsValidator } = profileValidations;
 const {
   expectedParamsValidator,
   nonEmptyParamsValidator,
-  existingTitleValidator
+  existingTitleValidator,
+  categoryValidator
 } = articleValidation;
 
 router.route('/articles')
@@ -22,7 +21,7 @@ router.route('/articles')
     expectedParamsValidator,
     nonEmptyParamsValidator,
     existingTitleValidator,
-    interestsValidator,
+    categoryValidator,
     createArticle
   );
 

--- a/test/article.test.js
+++ b/test/article.test.js
@@ -115,6 +115,22 @@ describe('ARTICLE TEST SUITE', () => {
         expect(response.body.title).to.equal('Test Space Trimming');
       });
 
+    it('should not create an article if category is invalid',
+      async () => {
+        const articleObject = {
+          title: '   Test Space Trimming    ',
+          body: 'Article Body',
+          description: 'Article Description',
+          category: 'Travel'
+        };
+
+        const response = await chai.request(server)
+          .post('/api/v1/articles')
+          .send(articleObject)
+          .set('Authorization', accesstoken);
+        expect(response.status).to.equal(400);
+      });
+
     it('should create an article when required fields are provided',
       (done) => {
         const articleObject = {

--- a/test/article.test.js
+++ b/test/article.test.js
@@ -118,7 +118,7 @@ describe('ARTICLE TEST SUITE', () => {
     it('should not create an article if category is invalid',
       async () => {
         const articleObject = {
-          title: '   Test Space Trimming    ',
+          title: ' New Article Title    ',
           body: 'Article Body',
           description: 'Article Description',
           category: 'Travel'
@@ -129,6 +129,7 @@ describe('ARTICLE TEST SUITE', () => {
           .send(articleObject)
           .set('Authorization', accesstoken);
         expect(response.status).to.equal(400);
+        expect(response.body.error.split(' ')[2]).to.equal('[Travel].');
       });
 
     it('should create an article when required fields are provided',

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,28 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { convertToArray } from '../helpers';
+
+chai.use(chaiHttp);
+
+describe('HELPER TEST SUITE', () => {
+  describe('convertToArray test suite', () => {
+    it('Should convert a string to an array', (done) => {
+      const result = convertToArray('Science');
+      expect(result[0]).to.equal('Science');
+      expect(Array.isArray(result)).to.equal(true);
+      done();
+    });
+
+    it('Should convert an object to an array', (done) => {
+      const result = convertToArray({ name: 'science' });
+      expect(Array.isArray(result)).to.equal(true);
+      done();
+    });
+
+    it('Should return the same input if an array is supplied', (done) => {
+      const result = convertToArray(['Science']);
+      expect(result[0]).to.equal('Science');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
#### Currently:

- When a user adds an invalid category to an article post, the user does not get back an error message, and our app's console receives the error: `invalid input value for enum “enum_Articles_category”: <invalid-category>`
- Also, if a user tries to update the `interests` column in his/her profile when there are no already existing interests, the user gets back an error message.

##### This PR fixes the above-mentioned bugs

- _Our current dataType for the `category` column in the `Article` table allows for only one category per article. This is left unchanged_.

#### What are the relevant pivotal tracker stories?
[#163397301](https://www.pivotaltracker.com/story/show/163397301)