### PR TITLE
[Feature #162727567]: Estimate read time of articles

### DIFF
--- a/controllers/article.js
+++ b/controllers/article.js
@@ -1,6 +1,6 @@
 import dateFns from 'date-fns';
 import models from '../models';
-import { generateSlug } from '../helpers';
+import { generateSlug, getReadTime } from '../helpers';
 
 const { Article, User, Profile } = models;
 
@@ -26,6 +26,7 @@ export default {
         category: category.trim(),
         slug: `${generateSlug(title)}-${user.username}`,
         userId,
+        readTime: getReadTime(body.trim())
       });
 
     return res.status(201).json({
@@ -34,6 +35,7 @@ export default {
       description: article.description,
       slug: article.slug,
       createdAt: article.createdAt,
+      readTime: article.readTime,
       author: {
         username: user.username,
         bio: profile.bio,

--- a/helpers/getReadTime.js
+++ b/helpers/getReadTime.js
@@ -1,3 +1,5 @@
-export default (article) => {
-
+export default (text) => {
+  const wordCount = text.match(/\S+/g).length;
+  const readTime = Math.floor(wordCount / 275);
+  return readTime || 1;
 };

--- a/helpers/getReadTime.js
+++ b/helpers/getReadTime.js
@@ -1,0 +1,3 @@
+export default (article) => {
+
+};

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,3 +1,4 @@
 export { default as generateSlug } from './generateSlug';
 export { default as categories } from './categories';
 export { default as convertToArray } from './convertToArray';
+export { default as getReadTime } from './getReadTime';

--- a/migrations/010-update-articles-read-time.js
+++ b/migrations/010-update-articles-read-time.js
@@ -1,0 +1,12 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface
+    .addColumn(
+      'Articles',
+      'readTime',
+      Sequelize.INTEGER
+    ),
+
+  /* eslint-disable no-unused-vars */
+  down: (queryInterface, Sequelize) => queryInterface
+    .remove('Articles', 'readTime')
+};

--- a/models/article.js
+++ b/models/article.js
@@ -37,6 +37,9 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.ENUM,
       values: ['Science', 'Technology', 'Engineering', 'Arts', 'Mathematics']
     },
+    readTime: {
+      type: DataTypes.INTEGER
+    },
   });
 
   Article.associate = (models) => {

--- a/test/010-helpers.test.js
+++ b/test/010-helpers.test.js
@@ -30,9 +30,15 @@ describe('HELPER TEST SUITE', () => {
   });
 
   describe('getReadTime test suite', () => {
-    it('Should get the read time of input text', (done) => {
+    it('Should return 1 for texts less than 550 words', (done) => {
       const readTime = getReadTime('There is fire on the mountain');
       expect(readTime).to.equal(1);
+      done();
+    });
+
+    it('Should get the read time of texts with over 550 words', (done) => {
+      const readTime = getReadTime('word '.repeat(1000));
+      expect(readTime).to.equal(3);
       done();
     });
   });

--- a/test/010-helpers.test.js
+++ b/test/010-helpers.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { convertToArray } from '../helpers';
+import { convertToArray, getReadTime } from '../helpers';
 
 describe('HELPER TEST SUITE', () => {
   describe('convertToArray test suite', () => {
@@ -25,6 +25,14 @@ describe('HELPER TEST SUITE', () => {
     it('Should not throw up a TypeError when no input is supplied', (done) => {
       const result = convertToArray();
       expect(typeof (result)).to.equal('object');
+      done();
+    });
+  });
+
+  describe('getReadTime test suite', () => {
+    it('Should get the read time of input text', (done) => {
+      const readTime = getReadTime('There is fire on the mountain');
+      expect(readTime).to.equal(1);
       done();
     });
   });


### PR DESCRIPTION
#### What does this PR do?
- it estimates read time for created articles
#### Description of Task to be completed?
- [x] create a helper for estimating read time
- [x] setup a migration file that adds a `readTime` column to Article model

#### How should this be manually tested?
- create an article at `POST /articles` and the estimated read time will be returned in the response object

#### Any background context you want to provide?
- Currently our articles do not contain images. Therefore this readTime estimator works with only text. It will be upgraded once image markdown format is determined

#### What are the relevant pivotal tracker stories?
[#162727567](https://www.pivotaltracker.com/n/projects/2229853/stories/162727567)