### PR TITLE
[Feature: #162727563] Pagination support for articles

### DIFF
--- a/controllers/article.js
+++ b/controllers/article.js
@@ -127,7 +127,7 @@ export default {
     }
     let offset;
     offset = limit * (page - 1);
-    if (page < 1) offset = 0;
+    if (!page || page < 1) offset = 0;
     const articles = await Article.findAll({
       order: [['createdAt', 'DESC']],
       where: { [and]: queryArray },
@@ -160,7 +160,7 @@ export default {
     })
     );
     return res.json({
-      articles: responseArray,
+      articles: responseArray
     });
   },
 

--- a/controllers/article.js
+++ b/controllers/article.js
@@ -113,15 +113,9 @@ export default {
     if (author) {
       queryArray.push({
         [or]: {
-          '$User.Profile.lastName$': {
-            [iLike]: `%${author}%`
-          },
-          '$User.Profile.firstName$': {
-            [iLike]: `%${author}%`
-          },
-          '$User.username$': {
-            [iLike]: `%${author}%`
-          },
+          '$User.Profile.lastName$': { [iLike]: `%${author}%` },
+          '$User.Profile.firstName$': { [iLike]: `%${author}%` },
+          '$User.username$': { [iLike]: `%${author}%` },
         }
       });
     }

--- a/controllers/article.js
+++ b/controllers/article.js
@@ -127,7 +127,7 @@ export default {
     }
     let offset;
     offset = limit * (page - 1);
-    if (!page || page < 1) offset = 0;
+    if (!page || page < 1 || !limit) offset = 0;
     const articles = await Article.findAll({
       order: [['createdAt', 'DESC']],
       where: { [and]: queryArray },

--- a/controllers/article.js
+++ b/controllers/article.js
@@ -4,18 +4,10 @@ import models from '../models';
 import { generateSlug, getReadTime, categories } from '../helpers';
 
 const {
-  Article,
-  User,
-  Profile,
-  Report,
-  Bookmark
+  Article, User, Profile, Report, Bookmark
 } = models;
 const {
-  iLike,
-  and,
-  or,
-  notIn,
-  contains
+  iLike, and, or, notIn, contains
 } = Sequelize.Op;
 
 export default {

--- a/controllers/article.js
+++ b/controllers/article.js
@@ -99,8 +99,9 @@ export default {
 
   async getArticles(req, res) {
     const {
-      category, author, tag, keywords, limit, page
+      category, author, tag, keywords, limit
     } = req.query;
+    let offset, { page } = req.query;
     const queryArray = [{
       [or]: {
         title: { [iLike]: keywords ? `%${keywords}%` : '%' },
@@ -119,9 +120,10 @@ export default {
         }
       });
     }
-    let offset;
     offset = limit * (page - 1);
-    if (!page || page < 1 || !limit) offset = 0;
+    if (!page || page < 1 || !limit) {
+      offset = 0; page = 1;
+    }
     const articles = await Article.findAll({
       order: [['createdAt', 'DESC']],
       where: { [and]: queryArray },
@@ -155,7 +157,8 @@ export default {
     );
     return res.json({
       articles: responseArray,
-      count: articles.length
+      count: articles.length,
+      page
     });
   },
 

--- a/controllers/article.js
+++ b/controllers/article.js
@@ -99,9 +99,16 @@ export default {
 
   async getArticles(req, res) {
     const {
-      category, author, tag, keywords, limit
+      category,
+      author,
+      tag,
+      keywords,
+      limit = 50
     } = req.query;
+
     let offset, { page } = req.query;
+    page = Number(page);
+
     const queryArray = [{
       [or]: {
         title: { [iLike]: keywords ? `%${keywords}%` : '%' },
@@ -121,7 +128,7 @@ export default {
       });
     }
     offset = limit * (page - 1);
-    if (!page || page < 1 || !limit) {
+    if (!page || page < 1) {
       offset = 0; page = 1;
     }
     const articles = await Article.findAll({

--- a/controllers/article.js
+++ b/controllers/article.js
@@ -99,7 +99,7 @@ export default {
 
   async getArticles(req, res) {
     const {
-      category, author, tag, keywords, limit,
+      category, author, tag, keywords, limit, page
     } = req.query;
     const queryArray = [{
       [or]: {
@@ -125,8 +125,9 @@ export default {
         }
       });
     }
-    const { page } = req.query;
-    const offset = limit * (page - 1);
+    let offset;
+    offset = limit * (page - 1);
+    if (page < 1) offset = 0;
     const articles = await Article.findAll({
       order: [['createdAt', 'DESC']],
       where: { [and]: queryArray },

--- a/controllers/article.js
+++ b/controllers/article.js
@@ -160,7 +160,8 @@ export default {
     })
     );
     return res.json({
-      articles: responseArray
+      articles: responseArray,
+      count: articles.length
     });
   },
 

--- a/controllers/article.js
+++ b/controllers/article.js
@@ -4,10 +4,18 @@ import models from '../models';
 import { generateSlug, getReadTime, categories } from '../helpers';
 
 const {
-  Article, User, Profile, Report, Bookmark
+  Article,
+  User,
+  Profile,
+  Report,
+  Bookmark
 } = models;
 const {
-  iLike, and, or, notIn, contains
+  iLike,
+  and,
+  or,
+  notIn,
+  contains
 } = Sequelize.Op;
 
 export default {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "errorhandler": "^1.5.0",
     "express": "^4.16.3",
     "express-jwt": "^5.3.1",
+    "express-paginate": "^1.0.0",
     "express-session": "^1.15.6",
     "jsonwebtoken": "^8.4.0",
     "morgan": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "errorhandler": "^1.5.0",
     "express": "^4.16.3",
     "express-jwt": "^5.3.1",
-    "express-paginate": "^1.0.0",
     "express-session": "^1.15.6",
     "jsonwebtoken": "^8.4.0",
     "morgan": "^1.9.0",

--- a/test/004-article.test.js
+++ b/test/004-article.test.js
@@ -19,9 +19,14 @@ describe('ARTICLE TEST SUITE', () => {
       email: 'davidhook@hotmail.com',
       password: 'davidhook345'
     };
-
-    const articleRequestObject = {
+    const firstArticleRequestObject = {
       title: 'Halt and Catch Fire',
+      body: 'Article Body',
+      description: 'Sci-fi movie',
+      category: 'Science'
+    };
+    const secondArticleRequestObject = {
+      title: 'Sherlock Holmes',
       body: 'Article Body',
       description: 'Sci-fi movie',
       category: 'Science'
@@ -30,12 +35,16 @@ describe('ARTICLE TEST SUITE', () => {
     const responseObject = await chai.request(server).post('/api/v1/users')
       .send(userRequestObject);
     accesstoken = responseObject.body.token;
-
-    const articleResponse = await chai.request(server)
+    const firstArticleResponse = await chai.request(server)
       .post(baseUrl)
-      .send(articleRequestObject)
+      .send(firstArticleRequestObject)
       .set('Authorization', accesstoken);
-    firstArticleSlug = articleResponse.body.slug;
+    firstArticleSlug = firstArticleResponse.body.slug;
+
+    await chai.request(server)
+      .post(baseUrl)
+      .send(secondArticleRequestObject)
+      .set('Authorization', accesstoken);
   });
 
   describe('CREATE ARTICLE', () => {
@@ -58,12 +67,10 @@ describe('ARTICLE TEST SUITE', () => {
         description: 'Article Description',
         category: 'Science'
       };
-
       const response = await chai.request(server)
         .post(baseUrl)
         .send(articleObject)
         .set('Authorization', accesstoken);
-
       const errorResult = JSON.parse(response.body.error);
       expect(response.status).to.equal(400);
       expect(errorResult[0]).to.equal('title is required');
@@ -77,12 +84,10 @@ describe('ARTICLE TEST SUITE', () => {
         description: 'Article Description',
         category: 'Article Category'
       };
-
       const response = await chai.request(server)
         .post(baseUrl)
         .send(articleObject)
         .set('Authorization', accesstoken);
-
       const errorResult = JSON.parse(response.body.error);
       expect(response.status).to.equal(400);
       expect(errorResult[0]).to.equal('title must not be empty');
@@ -96,12 +101,10 @@ describe('ARTICLE TEST SUITE', () => {
         description: 'Article Description',
         category: 'Science'
       };
-
       const response = await chai.request(server)
         .post(baseUrl)
         .send(articleObject)
         .set('Authorization', accesstoken);
-
       const errorResult = 'You already have an article with the same title';
       expect(response.status).to.equal(400);
       expect(response.body.error).to.equal(errorResult);
@@ -114,12 +117,10 @@ describe('ARTICLE TEST SUITE', () => {
         description: 'Article Description',
         category: 'Science'
       };
-
       const response = await chai.request(server)
         .post(baseUrl)
         .send(articleObject)
         .set('Authorization', accesstoken);
-
       expect(response.status).to.equal(201);
       expect(response.body.title).to.equal('Test Space Trimming');
     });
@@ -131,12 +132,10 @@ describe('ARTICLE TEST SUITE', () => {
         description: 'Article Description',
         category: 'Travel'
       };
-
       const response = await chai.request(server)
         .post('/api/v1/articles')
         .send(articleObject)
         .set('Authorization', accesstoken);
-
       expect(response.status).to.equal(400);
       expect(response.body.error.split(' ')[2]).to.equal('[Travel].');
     });
@@ -148,12 +147,10 @@ describe('ARTICLE TEST SUITE', () => {
         description: 'Article Description',
         category: 'Science'
       };
-
       const response = await chai.request(server)
         .post(baseUrl)
         .set('Authorization', accesstoken)
         .send(articleObject);
-
       expect(response.status).to.equal(201);
       expect(response.body.title).to.equal('New Article');
       expect(response.body.description).to.equal('Article Description');
@@ -165,12 +162,10 @@ describe('ARTICLE TEST SUITE', () => {
       const articleObject = {
         report: 'Article has erotic content, its inappropriate'
       };
-
       const response = await chai.request(server)
         .post(`${baseUrl}/report/${firstArticleSlug}`)
         .set('Authorization', accesstoken)
         .send(articleObject);
-
       expect(response.status).to.equal(201);
       expect(response.body.message).to.equal('Your report has been registered');
     });
@@ -206,7 +201,6 @@ describe('ARTICLE TEST SUITE', () => {
       // eslint-disable-next-line
       expect(response.body.error).to.equal('Report must have at least ten characters');
     });
-
     it('should not allow report for non existent article', async () => {
       const response = await chai.request(server)
         .post(`${baseUrl}/report/article-the-moon`)
@@ -223,12 +217,10 @@ describe('ARTICLE TEST SUITE', () => {
         title: 'New Article',
         tags: 'Article Body'
       };
-
       const response = await chai.request(server)
         .patch(`${baseUrl}/tag`)
         .set('Authorization', accesstoken)
         .send(articleObject);
-
       expect(response.status).to.equal(200);
     });
 
@@ -237,12 +229,10 @@ describe('ARTICLE TEST SUITE', () => {
         title: 'New Article',
         tags: 678899900000,
       };
-
       const response = await chai.request(server)
         .patch(`${baseUrl}/tag`)
         .set('Authorization', accesstoken)
         .send(articleObject);
-
       expect(response.status).to.equal(400);
       expect(response.body.error).to.equal('tag must be a string');
     });
@@ -252,12 +242,10 @@ describe('ARTICLE TEST SUITE', () => {
         title: 'New Article',
         tags: 'Article Body Two',
       };
-
       const response = await chai.request(server)
         .patch(`${baseUrl}/tag`)
         .set('Authorization', accesstoken)
         .send(articleObject);
-
       expect(response.status).to.equal(200);
     });
   });
@@ -266,7 +254,6 @@ describe('ARTICLE TEST SUITE', () => {
     it('should get an article', async () => {
       const response = await chai.request(server)
         .get(`${baseUrl}/${firstArticleSlug}`);
-
       expect(response.status).to.equal(200);
       expect(response.body.slug).to.equal('halt-and-catch-fire-davidhook');
     });
@@ -274,9 +261,29 @@ describe('ARTICLE TEST SUITE', () => {
     it('should not get a non existent article', async () => {
       const response = await chai.request(server)
         .get('/api/v1/articles/non-existing-article');
-
       expect(response.status).to.equal(404);
       expect(response.body.error).to.equal('Article provided does not exist');
+    });
+
+    it('should not get a non existent article', async () => {
+      const response = await chai.request(server)
+        .get('/api/v1/articles/non-existing-article');
+      expect(response.status).to.equal(404);
+      expect(response.body.error).to.equal('Article provided does not exist');
+    });
+
+    it('should have amount of returened data as specified', async () => {
+      const response = await chai.request(server)
+        .get('/api/v1/articles/?limit=2');
+      expect(response.status).to.equal(200);
+      expect(response.body.count).to.equal(2);
+    });
+
+    it('should return first page if query.page is less than 1', async () => {
+      const response = await chai.request(server)
+        .get('/api/v1/articles/?limit=2&page=-3');
+      expect(response.status).to.equal(200);
+      expect(response.body.page).to.equal(1);
     });
   });
 });

--- a/test/004-article.test.js
+++ b/test/004-article.test.js
@@ -285,5 +285,19 @@ describe('ARTICLE TEST SUITE', () => {
       expect(response.status).to.equal(200);
       expect(response.body.page).to.equal(1);
     });
+
+    it('should return first page if query.page is not provided', async () => {
+      const response = await chai.request(server)
+        .get('/api/v1/articles/?limit=2');
+      expect(response.status).to.equal(200);
+      expect(response.body.page).to.equal(1);
+    });
+
+    it('should return all articles if limit is not provided', async () => {
+      const response = await chai.request(server)
+        .get('/api/v1/articles/?page=1');
+      expect(response.status).to.equal(200);
+      expect(response.body.page).to.equal(1);
+    });
   });
 });

--- a/test/004-article.test.js
+++ b/test/004-article.test.js
@@ -265,13 +265,6 @@ describe('ARTICLE TEST SUITE', () => {
       expect(response.body.error).to.equal('Article provided does not exist');
     });
 
-    it('should not get a non existent article', async () => {
-      const response = await chai.request(server)
-        .get('/api/v1/articles/non-existing-article');
-      expect(response.status).to.equal(404);
-      expect(response.body.error).to.equal('Article provided does not exist');
-    });
-
     it('should have amount of returned data as specified', async () => {
       const response = await chai.request(server)
         .get('/api/v1/articles/?limit=2');

--- a/test/004-article.test.js
+++ b/test/004-article.test.js
@@ -297,7 +297,7 @@ describe('ARTICLE TEST SUITE', () => {
       const response = await chai.request(server)
         .get('/api/v1/articles/?page=1');
       expect(response.status).to.equal(200);
-      expect(response.body.page).to.equal(1);
+      expect(response.body.count).to.equal(4);
     });
   });
 });

--- a/test/004-article.test.js
+++ b/test/004-article.test.js
@@ -272,7 +272,7 @@ describe('ARTICLE TEST SUITE', () => {
       expect(response.body.error).to.equal('Article provided does not exist');
     });
 
-    it('should have amount of returened data as specified', async () => {
+    it('should have amount of returned data as specified', async () => {
       const response = await chai.request(server)
         .get('/api/v1/articles/?limit=2');
       expect(response.status).to.equal(200);


### PR DESCRIPTION
#### What does this PR do?
- This PR adds pagination support for Articles. 

#### Description of Task to be completed?
- Requests can include the number of articles that can be viewed per page and can allow navigation to different pages

#### How should this be manually tested?
- send a `GET` request to `/api/v1/articles/?limit=[amount-of-articles-per-page]&page=[page-number]`

#### What are the relevant pivotal tracker stories?
[#162727563](https://www.pivotaltracker.com/story/show/162727563)
