### PR TITLE
[Feature: #162727572] Allow user to get reading stats

### DIFF
--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -3,7 +3,7 @@ import models from '../models';
 
 dotenv.config();
 
-const { Profile } = models;
+const { Profile, Article, Reaction } = models;
 
 /**
  * @class
@@ -54,6 +54,48 @@ class Profiles {
       bio: responseData.bio,
       interests: responseData.interests,
       imageURL: responseData.imageURL
+    });
+  }
+
+  /**
+    * Represents a controller.
+    * @constructor
+    * @param {object} req - The request object.
+    * @param {object} res - The response object.
+    */
+  static async getUserStats(req, res) {
+    const { id } = req.decoded;
+    const authoredArticles = await Article.findAll({
+      where: { userId: id },
+      attributes: ['slug', 'description', 'title']
+    });
+    const likedArticles = await Reaction.findAll({
+      where: {
+        likedOrDislikedBy: id,
+        liked: true
+      },
+      attributes: [],
+      include: [
+        {
+          model: Article,
+          attributes: ['slug', 'description', 'title']
+        }
+      ]
+    });
+    const formattedLikedArticles = likedArticles.map(item => ({
+      slug: item.Article.slug,
+      description: item.Article.description,
+      title: item.Article.title
+    }));
+    res.json({
+      authored: {
+        articles: authoredArticles,
+        count: authoredArticles.length
+      },
+      liked: {
+        articles: formattedLikedArticles,
+        count: formattedLikedArticles.length
+      }
     });
   }
 }

--- a/controllers/profile.js
+++ b/controllers/profile.js
@@ -87,6 +87,34 @@ class Profiles {
       description: item.Article.description,
       title: item.Article.title
     }));
+    let topArticles = await Article.findAll({
+      attributes: ['slug', 'description', 'title'],
+      include: [
+        {
+          model: Reaction,
+          attributes: ['liked'],
+          where: { liked: true }
+        }
+      ]
+    });
+    topArticles.sort((a, b) => b.Reactions.length - a.Reactions.length);
+    let formattedTopArticles = topArticles.map(item => ({
+      slug: item.slug,
+      description: item.description,
+      title: item.title
+    }));
+
+    if (!topArticles.length) {
+      topArticles = await Article.findAll({
+        attributes: ['slug', 'description', 'title', 'body']
+      });
+      topArticles.sort((a, b) => b.body.length - a.body.length);
+      formattedTopArticles = topArticles.map(item => ({
+        slug: item.slug,
+        description: item.description,
+        title: item.title
+      }));
+    }
     res.json({
       authored: {
         articles: authoredArticles,
@@ -95,6 +123,10 @@ class Profiles {
       liked: {
         articles: formattedLikedArticles,
         count: formattedLikedArticles.length
+      },
+      top: {
+        articles: formattedTopArticles.slice(0, 5),
+        count: formattedTopArticles.slice(0, 5).length
       }
     });
   }

--- a/models/article.js
+++ b/models/article.js
@@ -61,6 +61,11 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'articleId',
       onDelete: 'CASCADE'
     });
+
+    Article.hasMany(models.Reaction, {
+      foreignKey: 'articleId',
+      onDelete: 'CASCADE'
+    });
   };
   return Article;
 };

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { Profile, Follow } from '../controllers';
+import { Profile, Follow, getUserStats } from '../controllers';
 import {
   verifyToken,
   profileValidations,
@@ -29,5 +29,8 @@ router.route('/following')
 
 router.route('/followers')
   .get(verifyToken, getFollowers);
+
+router.route('/stats')
+  .get(getUserStats);
 
 export default router;

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { Profile, Follow, getUserStats } from '../controllers';
+import { Profile, Follow } from '../controllers';
 import {
   verifyToken,
   profileValidations,
@@ -7,7 +7,7 @@ import {
 } from '../middlewares';
 
 const { interestsValidator, nameValidator } = profileValidations;
-const { updateProfile } = Profile;
+const { updateProfile, getUserStats } = Profile;
 const { canFollowUser } = followValidations;
 const { followUser, getFollowing, getFollowers } = Follow;
 const router = express.Router();
@@ -31,6 +31,6 @@ router.route('/followers')
   .get(verifyToken, getFollowers);
 
 router.route('/stats')
-  .get(getUserStats);
+  .get(verifyToken, getUserStats);
 
 export default router;

--- a/test/003-profile.test.js
+++ b/test/003-profile.test.js
@@ -10,7 +10,7 @@ const articleUrl = '/api/v1/articles';
 let article1Response;
 let article2Response;
 
-describe.only('PROFILE TEST SUITE', () => {
+describe('PROFILE TEST SUITE', () => {
   let user1Token, user2Token;
   before(async () => {
     await models.sequelize.sync({ force: true });


### PR DESCRIPTION
#### What does this PR do?
- It ensures a user can get his/her reading stats

#### Description of Task to be completed?
- [x] Create a route for getting a user's reading stats

#### How should this be manually tested?
- goto `GET /profile/stats` with a valid authorization token and a response body containing the top articles, authored articles and liked articles by the user will be received

#### What are the relevant pivotal tracker stories?
[#162727572](https://www.pivotaltracker.com/n/projects/2229853/stories/162727572)