### PR TITLE
[chore: #163993499] Enable Trust Proxy for SSL

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ const app = express();
 
 initPassport();
 
+app.enable('trust proxy');
 app.use(cors());
 
 // Normal express config defaults


### PR DESCRIPTION
#### What does this PR do?
- This PR enables `trust proxy` in order to get `https` from `req.protocol`

#### What are the relevant pivotal tracker stories?
[#163993499](https://www.pivotaltracker.com/story/show/163993499)