### PR TITLE
Feature/164133273/article additional details

### DIFF
--- a/models/comment.js
+++ b/models/comment.js
@@ -23,6 +23,12 @@ module.exports = (sequelize, DataTypes) => {
     Comment.belongsTo(models.Article, {
       foreignKey: 'articleId'
     });
+    Comment.belongsTo(models.User, {
+      foreignKey: 'userId'
+    });
+    Comment.hasMany(models.CommentReaction, {
+      foreignKey: 'commentId'
+    });
   };
   return Comment;
 };


### PR DESCRIPTION
#### What does this PR do?
- It ensures the `GET /articles/:slug` route returns an article with its author, comments, and total likes. 

#### Description of Task to be completed?
- add comments-user and comments-commentReactions relationships
- add author, comments, and likes to any article returned from this route

#### How should this be manually tested?
Goto `GET /articles/:slug` to view an article. It should include the new details

#### What are the relevant pivotal tracker stories?
[#164133273](https://www.pivotaltracker.com/n/projects/2229853/stories/164133273)

#### Screenshots (if appropriate)
Before:

<img width="676" alt="before" src="https://user-images.githubusercontent.com/12197866/53166558-ec48a200-35d5-11e9-8d16-0660218fca1f.png">

After: 
<img width="1051" alt="after" src="https://user-images.githubusercontent.com/12197866/53166577-fa96be00-35d5-11e9-93e7-5eb9ce344e96.png">


