### PR TITLE
[Chore: #164276773] Reimplement article bookmark

### DIFF
--- a/middlewares/articleValidation.js
+++ b/middlewares/articleValidation.js
@@ -135,20 +135,25 @@ export default {
     } = req;
 
     const article = await Article.findOne({ where: { slug } });
+    if (!article) {
+      const error = new Error('Article does not exist!');
+      error.status = 404;
+      return next(error);
+    }
     const articleId = article.id;
     const bookmark = await Bookmark.findOne({
       where: { articleId, bookmarkedBy: userId }
     });
 
     if (!bookmark && method === 'DELETE') {
-      const error = new Error('This Article is not bookmarked');
+      const error = new Error('This Article is not bookmarked!');
       error.status = 404;
       return next(error);
     }
 
     if (bookmark && method === 'POST') {
-      const error = new Error('This Article is already bookmarked');
-      error.status = 404;
+      const error = new Error('This Article is already bookmarked!');
+      error.status = 401;
       return next(error);
     }
 

--- a/middlewares/authentication.js
+++ b/middlewares/authentication.js
@@ -34,4 +34,24 @@ const verifyToken = (req, res, next) => {
   });
 };
 
-export default verifyToken;
+const getUserId = (req, res, next) => {
+  const token = req.headers.authorization;
+
+  jwt.verify(token, secret, async (err, decoded) => {
+    if (!token || err) {
+      req.decoded = null;
+      return next();
+    }
+
+    const user = await User.findByPk(decoded.id);
+    if (!user) {
+      req.decoded = null;
+      return next();
+    }
+
+    req.decoded = decoded;
+    return next();
+  });
+};
+
+export { verifyToken, getUserId };

--- a/middlewares/index.js
+++ b/middlewares/index.js
@@ -2,7 +2,7 @@ export { default as errorHandler } from './errorHandler';
 export { default as userValidations } from './userValidations';
 export { default as profileValidations } from './profileValidations';
 export { default as notFoundRoute } from './notFoundRoute';
-export { default as verifyToken } from './authentication';
+export { verifyToken, getUserId } from './authentication';
 export { default as articleValidation } from './articleValidation';
 export { default as followValidations } from './followValidations';
 export { default as commentValidations } from './commentValidations';

--- a/routes/articleRoutes.js
+++ b/routes/articleRoutes.js
@@ -10,6 +10,7 @@ import {
 
 import {
   verifyToken,
+  getUserId,
   articleValidation,
   commentValidations,
   ratingValidation,
@@ -57,7 +58,7 @@ const {
   reportIsEmpty,
   reportIsRequired,
   categoryQueryValidator,
-  checkIfSlugExists,
+  doesBookmarkExist,
   isInputValid
 } = articleValidation;
 
@@ -125,12 +126,12 @@ router.route('/bookmarks')
 
 router.route('/bookmarks/:slug')
   .all(verifyToken)
-  .post(checkIfSlugExists, bookmarkArticle)
-  .patch(checkIfSlugExists, removeBookmarkedArticle);
-
+  .post(doesBookmarkExist, bookmarkArticle)
+  .delete(doesBookmarkExist, removeBookmarkedArticle);
 
 router.route('/:slug')
   .get(
+    getUserId,
     doesArticleExist,
     getArticleBySlug
   );

--- a/test/013-bookmark.test.js
+++ b/test/013-bookmark.test.js
@@ -10,6 +10,7 @@ const baseUrl = '/api/v1';
 describe('BOOKMARK TEST SUITE', () => {
   let accessToken;
   let createdSlug;
+  let articleRequestObject;
 
   before(async () => {
     await models.sequelize.sync({ force: true });
@@ -20,7 +21,7 @@ describe('BOOKMARK TEST SUITE', () => {
       password: 'john26354'
     };
 
-    const articleRequestObject = {
+    articleRequestObject = {
       title: 'The new boston',
       body: 'Bucky rubert is the only person you hear in the newboston',
       description: 'Article Description for get all authors',
@@ -40,64 +41,43 @@ describe('BOOKMARK TEST SUITE', () => {
   });
 
   describe('BOOKMARK AN ARTICLE', () => {
-    // eslint-disable-next-line max-len
     it('Should not bookmark an article when the slug does not exist',
       async () => {
         const response = await chai.request(server)
-          .post(`${baseUrl}/articles/bookmarks/the-new-looks`)
+          .post(`${baseUrl}/articles/bookmark/the-new-looks`)
           .set('Authorization', accessToken);
-        expect(response.status).to.equal(400);
+        expect(response.status).to.equal(404);
         expect(response.body).to.have.deep.property('error');
-        expect(response.body.error).to.equal('Article does not exist');
+        expect(response.body.error).to.equal('Article does not exist!');
       }
     );
 
     it('should bookmark article when slug exists', async () => {
       const response = await chai.request(server)
-        .post(`${baseUrl}/articles/bookmarks/${createdSlug}`)
+        .post(`${baseUrl}/articles/bookmark/${createdSlug}`)
         .set('Authorization', accessToken);
       expect(response.status).to.equal(201);
-    }
-    );
+      expect(response.body.message).to.equal('Bookmark successful!');
+    });
 
-    it('should get array of slugs from bookmarked articles',
+    it('should get a user\'s bookmarks',
       async () => {
         const response = await chai.request(server)
           .get(`${baseUrl}/articles/bookmarks`)
           .set('Authorization', accessToken);
         expect(response.status).to.equal(200);
-        expect(response.body[0]).to.equal('the-new-boston-JohnDoe');
+        expect(response.body.bookmarks[0].title).to.equal('The new boston');
       }
     );
 
-    // eslint-disable-next-line
-    it('should not remove article from list of bookmarked articles when article slug does not exist',
+    it('should not remove bookmark if it does not exist',
       async () => {
         const response = await chai.request(server)
-          .patch(`${baseUrl}/articles/bookmarks/time-shall-tell-for-perfection`)
+          .delete(`${baseUrl}/articles/bookmark/time-shall-tell-for-perfection`)
           .set('Authorization', accessToken);
-        expect(response.status).to.equal(400);
+        expect(response.status).to.equal(404);
         expect(response.body).to.have.deep.property('error');
-        expect(response.body.error).to.equal('Article does not exist');
-      }
-    );
-
-    it('should bookmark article when article slug exists',
-      async () => {
-        const response = await chai.request(server)
-          .patch(`${baseUrl}/articles/bookmarks/${createdSlug}`)
-          .set('Authorization', accessToken);
-        expect(response.status).to.equal(200);
-      }
-    );
-
-    it('should return array of slugs for bookmarked articles',
-      async () => {
-        const response = await chai.request(server)
-          .get(`${baseUrl}/articles/bookmarks`)
-          .set('Authorization', accessToken);
-        expect(response.status).to.equal(200);
-        expect(response.body.length).to.equal(0);
+        expect(response.body.error).to.equal('Article does not exist!');
       }
     );
   });

--- a/test/013b-bookmark.test.js
+++ b/test/013b-bookmark.test.js
@@ -103,7 +103,7 @@ describe('BOOKMARK TEST SUITE', () => {
     it('should not remove bookmark if article does not exist',
       async () => {
         const response = await chai.request(server)
-          .delete(`${baseUrl}/articles/bookmarks/time-shall-tell-for-perfection`)
+          .delete(`${baseUrl}/articles/bookmarks/time-shall-tell`)
           .set('Authorization', accessToken);
         expect(response.status).to.equal(404);
         expect(response.body).to.have.deep.property('error');


### PR DESCRIPTION
#### What does this PR do?
- This `PR` reimplements `article bookmark`

#### Description of Task to be completed?
- Return valid response when a user bookmarks an article
- Prevent a user from bookmarking/ deleting a bookmark twice in a row
- Actually delete a bookmark when a user sends a `DELETE` request
- Add bookmark state to the `response object` when a user requests for an article

#### How should this be manually tested?
- send a `GET` request to `/articles/bookmarks` to get all user's bookmarks
- send a `POST` request to `/articles/bookmarks/:slug` to add a bookmark
- send a `DELETE` request to `/articles/bookmarks/:slug` to delete a bookmark

#### What are the relevant pivotal tracker stories?
[#164276773](https://www.pivotaltracker.com/story/show/164276773)
