### PR TITLE
[Feature: #164320967] Article highlights should be included in article object

### DIFF
--- a/controllers/article.js
+++ b/controllers/article.js
@@ -13,7 +13,8 @@ const {
   Follow,
   Comment,
   Reaction,
-  CommentReaction
+  CommentReaction,
+  Highlight
 } = models;
 const {
   iLike,
@@ -227,6 +228,21 @@ export default {
           model: Reaction,
           where: { liked: true },
           required: false
+        },
+        {
+          model: Highlight,
+          required: false,
+          include: [{
+            model: User,
+            required: false,
+            attributes: ['username'],
+            include: [{
+              model: Profile,
+              required: false,
+              attributes: ['firstName', 'lastName', 'imageUrl']
+            }]
+          },
+          ]
         }
       ]
     });
@@ -241,6 +257,21 @@ export default {
         lastName: commentItem.User.Profile.lastName,
         imageUrl: commentItem.User.Profile.imageUrl,
         username: commentItem.User.username
+      }
+    }));
+
+    const highlights = article.Highlights.map(highlight => ({
+      id: highlight.id,
+      highlightedText: highlight.highlightedText,
+      startIndex: highlight.startIndex,
+      stopIndex: highlight.stopIndex,
+      comment: highlight.comment,
+      createdAt: highlight.createdAt,
+      author: {
+        firstName: highlight.User.Profile.firstName,
+        lastName: highlight.User.Profile.lastName,
+        imageUrl: highlight.User.Profile.imageUrl,
+        username: highlight.User.username
       }
     }));
 
@@ -276,7 +307,8 @@ export default {
         firstName: article.User.Profile.firstName,
         lastName: article.User.Profile.lastName,
         imageUrl: article.User.Profile.imageUrl
-      }
+      },
+      highlights
     };
     return res.json(response);
   },

--- a/models/article.js
+++ b/models/article.js
@@ -69,6 +69,11 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'articleId',
       onDelete: 'CASCADE'
     });
+
+    Article.hasMany(models.Highlight, {
+      foreignKey: 'articleId',
+      onDelete: 'CASCADE'
+    });
   };
   return Article;
 };


### PR DESCRIPTION
#### What does this PR do?
- It ensures that the `GET /articles/:slug` route returns the highlights on the article along with the article

#### Description of Task to be completed?
- [x] add table relationships for article and highlights
- [x] add highlights to returned article

#### How should this be manually tested?
- goto `GET /articles/:slug` to get an article
- the response should include the highlights and comments on the article if there are any

#### What are the relevant pivotal tracker stories?`
[#164320967](https://www.pivotaltracker.com/n/projects/2229853/stories/164320967)
#### Screenshots (if appropriate)

